### PR TITLE
88 update get game ads based on seller

### DIFF
--- a/src/main/java/SecondRoll/demo/controllers/GameAdsController.java
+++ b/src/main/java/SecondRoll/demo/controllers/GameAdsController.java
@@ -3,6 +3,7 @@ package SecondRoll.demo.controllers;
 import SecondRoll.demo.models.EGameCategory;
 import SecondRoll.demo.models.GameAds;
 import SecondRoll.demo.payload.CreateGameDTO;
+import SecondRoll.demo.payload.response.GameAdResponse;
 import SecondRoll.demo.services.GameAdsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -27,10 +28,11 @@ public class GameAdsController {
         return new ResponseEntity<>(gameAd, HttpStatus.CREATED);
     }
 
-    // GET
+    // GET ALL gameAds.
     @GetMapping("/all")
-    public List<GameAds> getAllGameAds() {
-        return gameAdsService.getAllGameAds();
+    public ResponseEntity<List<GameAdResponse>> getAllGameAds() {
+        List<GameAdResponse> orders = gameAdsService.getAllGameAds();
+        return ResponseEntity.ok(orders);
     }
 
     // PUT
@@ -60,10 +62,11 @@ public class GameAdsController {
         return gameAdsService.findGameAdsByGameDetails(gameDetails);
     }
 
-
-    @GetMapping(value = "/search/userId")
-    public List<GameAds> findGameAdsByUserId(@RequestParam String userId) {
-        return gameAdsService.findGameAdsByUserId(userId);
+    // UPDATED GET all game ads belonging to a user.
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<GameAdResponse>> getUserOrders(@PathVariable String userId) {
+        List<GameAdResponse> gameAds = gameAdsService.getUserOrders(userId);
+        return ResponseEntity.ok(gameAds);
     }
 
     // "Roll the Dice" game ad randomizer
@@ -72,3 +75,10 @@ public class GameAdsController {
         return gameAdsService.getRandomGameAd();
     }
 }
+
+
+ /* // GET all game ads belonging to a user.
+    @GetMapping(value = "/search/userId")
+    public List<GameAds> findGameAdsByUserId(@RequestParam String userId) {
+        return gameAdsService.findGameAdsByUserId(userId);
+    } */

--- a/src/main/java/SecondRoll/demo/controllers/GameAdsController.java
+++ b/src/main/java/SecondRoll/demo/controllers/GameAdsController.java
@@ -1,5 +1,6 @@
 package SecondRoll.demo.controllers;
 
+import SecondRoll.demo.exception.EntityNotFoundException;
 import SecondRoll.demo.models.EGameCategory;
 import SecondRoll.demo.models.GameAds;
 import SecondRoll.demo.payload.CreateGameDTO;
@@ -16,12 +17,11 @@ import java.util.Optional;
 @RestController
 @RequestMapping(value="/api/gameAds")
 public class GameAdsController {
-    @Autowired
 
+    @Autowired
     GameAdsService gameAdsService;
 
-
-    // POST
+    // POST.
     @PostMapping()
     public ResponseEntity<GameAds> createGameAd(@RequestBody CreateGameDTO createGameDTO) {
         GameAds gameAd = gameAdsService.createGameAd(createGameDTO);
@@ -35,13 +35,18 @@ public class GameAdsController {
         return ResponseEntity.ok(orders);
     }
 
-    // PUT
-    @PutMapping()
-    public GameAds updateGameAd(@RequestBody GameAds gameAds) {
-        return gameAdsService.updateGameAd(gameAds);
+    // UPDATED PUT.
+    @PutMapping("/{gameId}")
+    public ResponseEntity<?> updateGameAd(@PathVariable String gameId, @RequestBody GameAds gameDetails) {
+        try {
+            GameAds updatedGameAd = gameAdsService.updateGameAd(gameId, gameDetails);
+            return ResponseEntity.ok(updatedGameAd);
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
     }
 
-    // GET by id
+    // GET a gameAd by ID.
     @GetMapping(value = "/{id}")
     public ResponseEntity<GameAds> getGameAdById(@PathVariable String id) {
         Optional<GameAds> gameAds = gameAdsService.getGameAdById(id);
@@ -50,13 +55,13 @@ public class GameAdsController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    // Delete by id
+    // Delete by ID.
     @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
     public String deleteGameAd(@PathVariable String id) {
         return gameAdsService.deleteGameAd(id);
     }
 
-
+    // FILTER by enum.
     @GetMapping(value = "/search")
     public List<GameAds> findGameAdsByGameDetails(@RequestParam List<EGameCategory> gameDetails) {
         return gameAdsService.findGameAdsByGameDetails(gameDetails);
@@ -77,8 +82,16 @@ public class GameAdsController {
 }
 
 
- /* // GET all game ads belonging to a user.
+
+ /* // OLD GET all game ads belonging to a user, stored for now, just in case.
     @GetMapping(value = "/search/userId")
     public List<GameAds> findGameAdsByUserId(@RequestParam String userId) {
         return gameAdsService.findGameAdsByUserId(userId);
+    } */
+
+ /*
+    // OLD PUT Update a game ad, stored for now, just in case.
+    @PutMapping()
+    public GameAds updateGameAd(@RequestBody GameAds gameAds) {
+        return gameAdsService.updateGameAd(gameAds);
     } */

--- a/src/main/java/SecondRoll/demo/controllers/GameAdsController.java
+++ b/src/main/java/SecondRoll/demo/controllers/GameAdsController.java
@@ -3,6 +3,7 @@ package SecondRoll.demo.controllers;
 import SecondRoll.demo.exception.EntityNotFoundException;
 import SecondRoll.demo.models.EGameCategory;
 import SecondRoll.demo.models.GameAds;
+import SecondRoll.demo.models.User;
 import SecondRoll.demo.payload.CreateGameDTO;
 import SecondRoll.demo.payload.response.GameAdResponse;
 import SecondRoll.demo.services.GameAdsService;
@@ -23,9 +24,12 @@ public class GameAdsController {
 
     // POST.
     @PostMapping()
-    public ResponseEntity<GameAds> createGameAd(@RequestBody CreateGameDTO createGameDTO) {
+    public ResponseEntity<GameAdResponse> createGameAd(@RequestBody CreateGameDTO createGameDTO) {
         GameAds gameAd = gameAdsService.createGameAd(createGameDTO);
-        return new ResponseEntity<>(gameAd, HttpStatus.CREATED);
+        User user = gameAd.getUser();
+        return ResponseEntity.ok().body(new GameAdResponse(user.getUsername(), gameAd.getTitle(),
+                gameAd.getDescription(), gameAd.getPrice(), gameAd.getShippingCost(),
+                gameAd.getGameDetails(), gameAd.getCreated_at(), gameAd.getUpdated_at()));
     }
 
     // GET ALL gameAds.
@@ -40,7 +44,11 @@ public class GameAdsController {
     public ResponseEntity<?> updateGameAd(@PathVariable String gameId, @RequestBody GameAds gameDetails) {
         try {
             GameAds updatedGameAd = gameAdsService.updateGameAd(gameId, gameDetails);
-            return ResponseEntity.ok(updatedGameAd);
+            User user = updatedGameAd.getUser();
+            return ResponseEntity.ok().body(new GameAdResponse(user.getUsername(), updatedGameAd.getTitle(),
+                    updatedGameAd.getDescription(), updatedGameAd.getPrice(), updatedGameAd.getShippingCost(),
+                    updatedGameAd.getGameDetails(), updatedGameAd.getCreated_at(),
+                    updatedGameAd.getUpdated_at()));
         } catch (EntityNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
@@ -48,11 +56,17 @@ public class GameAdsController {
 
     // GET a gameAd by ID.
     @GetMapping(value = "/{id}")
-    public ResponseEntity<GameAds> getGameAdById(@PathVariable String id) {
-        Optional<GameAds> gameAds = gameAdsService.getGameAdById(id);
+    public ResponseEntity<?> getGameAdById(@PathVariable String id) {
+        try {
+            Optional<GameAds> gameAd = gameAdsService.getGameAdById(id);
+            User user = gameAd.get().getUser();
 
-        return gameAds.map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
+            return ResponseEntity.ok().body(new GameAdResponse(user.getUsername(), gameAd.get().getTitle(),
+                    gameAd.get().getDescription(), gameAd.get().getPrice(), gameAd.get().getShippingCost(),
+                    gameAd.get().getGameDetails(), gameAd.get().getCreated_at(), gameAd.get().getUpdated_at()));
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
     }
 
     // Delete by ID.
@@ -76,8 +90,12 @@ public class GameAdsController {
 
     // "Roll the Dice" game ad randomizer
     @GetMapping(value = "/rolldice")
-    public GameAds getRandomGameAd() {
-        return gameAdsService.getRandomGameAd();
+    public ResponseEntity<GameAdResponse> getRandomGameAd() {
+        GameAds gameAd = gameAdsService.getRandomGameAd();
+        User user = gameAd.getUser();
+        return ResponseEntity.ok().body(new GameAdResponse(user.getUsername(), gameAd.getTitle(),
+                gameAd.getDescription(), gameAd.getPrice(), gameAd.getShippingCost(), gameAd.getGameDetails(),
+                gameAd.getCreated_at(), gameAd.getUpdated_at()));
     }
 }
 

--- a/src/main/java/SecondRoll/demo/models/GameAds.java
+++ b/src/main/java/SecondRoll/demo/models/GameAds.java
@@ -30,9 +30,6 @@ public class GameAds {
     @CreatedDate
     private LocalDate updated_at;
 
-
-
-
     // ArrayList of gameAds for picking a randomized game ad for a user
     private List<GameAds> gameAdsList;
 
@@ -44,6 +41,14 @@ public class GameAds {
 
     public List<EGameCategory> gameDetails = new ArrayList<>();
 
+    public boolean isAvailable() {
+        return isAvailable;
+    }
+
+    public void setAvailable(boolean available) {
+        isAvailable = available;
+    }
+
     public boolean isAvailable = true;
 
    // public List<EGameCategory> tags = new ArrayList<>();
@@ -52,7 +57,6 @@ public class GameAds {
     public void setId(String id) {
         this.id = id;
     }
-
 
     public void setTitle(String title) {
         this.title = title;
@@ -105,8 +109,6 @@ public class GameAds {
         return updated_at;
     }
 
-
-
    public List<EGameCategory> getGameDetails() {
         return gameDetails;
     }
@@ -117,14 +119,6 @@ public class GameAds {
 
     public int getShippingCost() {
         return shippingCost;
-    }
-
-    public boolean isAvailable() {
-        return isAvailable;
-    }
-
-    public void setAvailable(boolean available) {
-        isAvailable = available;
     }
 
     public User getUser() {

--- a/src/main/java/SecondRoll/demo/models/GameAds.java
+++ b/src/main/java/SecondRoll/demo/models/GameAds.java
@@ -31,11 +31,6 @@ public class GameAds {
     @CreatedDate
     private LocalDate updated_at;
 
-<<<<<<< HEAD
-=======
-
-
-
     // HELENA:
     // vad är det som händer här?
     // varför sparar ni en array med GameAds inne i själva GameAds modellen? det blir väl oerhört konstigt eller?
@@ -45,7 +40,6 @@ public class GameAds {
     // wierd, right? ^^
     // ta väck det här...
 
->>>>>>> e250957924213b72478cdeb86425fbdd158b8720
     // ArrayList of gameAds for picking a randomized game ad for a user
     private List<GameAds> gameAdsList;
 
@@ -150,9 +144,6 @@ public class GameAds {
     public void setUser(User user) {
         this.user = user;
     }
-
-
-
 
    /* public List<EGameCategory> getTags() {
         return tags;

--- a/src/main/java/SecondRoll/demo/payload/response/GameAdResponse.java
+++ b/src/main/java/SecondRoll/demo/payload/response/GameAdResponse.java
@@ -8,8 +8,6 @@ import java.util.List;
 
 public class GameAdResponse {
 
-    //private String userId? Do we still want to see ID's too, or only username?
-
     private String username;
 
     private String title;

--- a/src/main/java/SecondRoll/demo/payload/response/GameAdResponse.java
+++ b/src/main/java/SecondRoll/demo/payload/response/GameAdResponse.java
@@ -16,7 +16,7 @@ public class GameAdResponse {
 
     private int price;
 
-    private int shippingCost = 50;
+    private int shippingCost;
 
     private LocalDate created_at;
 

--- a/src/main/java/SecondRoll/demo/payload/response/GameAdResponse.java
+++ b/src/main/java/SecondRoll/demo/payload/response/GameAdResponse.java
@@ -24,6 +24,21 @@ public class GameAdResponse {
 
     public List<EGameCategory> gameDetails = new ArrayList<>();
 
+    public GameAdResponse(String username, String title, String description, int price, int shippingCost, List<EGameCategory> gameDetails
+    , LocalDate created_at, LocalDate updated_at) {
+        this.username = username;
+        this.title = title;
+        this.description = description;
+        this.price = price;
+        this.shippingCost = shippingCost;
+        this.gameDetails = gameDetails;
+        this.created_at = created_at;
+        this.updated_at = updated_at;
+    }
+
+    public GameAdResponse() {
+    }
+
     // private boolean isAvailable? Returns twice in postman right now. Looking for a fix.
 
     // GETTERS & SETTERS.

--- a/src/main/java/SecondRoll/demo/payload/response/GameAdResponse.java
+++ b/src/main/java/SecondRoll/demo/payload/response/GameAdResponse.java
@@ -1,14 +1,16 @@
-package SecondRoll.demo.payload;
+package SecondRoll.demo.payload.response;
 
 import SecondRoll.demo.models.EGameCategory;
-import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
-public class CreateGameDTO {
+public class GameAdResponse {
 
-    private String userId;
+    //private String userId? Do we still want to see ID's too, or only username?
+
+    private String username;
 
     private String title;
 
@@ -18,24 +20,22 @@ public class CreateGameDTO {
 
     private int shippingCost = 50;
 
-    @CreatedDate
     private LocalDate created_at;
 
-    @CreatedDate
     private LocalDate updated_at;
 
-    public List<EGameCategory> gameDetails;
+    public List<EGameCategory> gameDetails = new ArrayList<>();
 
     // private boolean isAvailable? Returns twice in postman right now. Looking for a fix.
 
     // GETTERS & SETTERS.
 
-    public String getUserId() {
-        return userId;
+    public String getUsername() {
+        return username;
     }
 
-    public void setUserId(String userId) {
-        this.userId = userId;
+    public void setUsername(String username) {
+        this.username = username;
     }
 
     public String getTitle() {

--- a/src/main/java/SecondRoll/demo/repository/GameAdsRepository.java
+++ b/src/main/java/SecondRoll/demo/repository/GameAdsRepository.java
@@ -8,16 +8,11 @@ import java.util.List;
 
 public interface GameAdsRepository extends MongoRepository<GameAds, String> {
 
-
     List<GameAds> findByGameDetailsIn(List<EGameCategory> gameDetails);
 
-<<<<<<< HEAD
     List<GameAds> findByUserId(String userId);
-=======
+
     List<GameAds> findByPrice(List<GameAds> price);
-
-
->>>>>>> e250957924213b72478cdeb86425fbdd158b8720
 
 }
 

--- a/src/main/java/SecondRoll/demo/repository/GameAdsRepository.java
+++ b/src/main/java/SecondRoll/demo/repository/GameAdsRepository.java
@@ -11,5 +11,7 @@ public interface GameAdsRepository extends MongoRepository<GameAds, String> {
 
     List<GameAds> findByGameDetailsIn(List<EGameCategory> gameDetails);
 
+    List<GameAds> findByUserId(String userId);
+
 }
 

--- a/src/main/java/SecondRoll/demo/services/GameAdsService.java
+++ b/src/main/java/SecondRoll/demo/services/GameAdsService.java
@@ -1,5 +1,6 @@
 package SecondRoll.demo.services;
 
+import SecondRoll.demo.exception.EntityNotFoundException;
 import SecondRoll.demo.models.EGameCategory;
 import SecondRoll.demo.models.GameAds;
 import SecondRoll.demo.models.User;
@@ -17,12 +18,13 @@ import java.util.stream.Collectors;
 
 @Service
 public class GameAdsService {
+
     @Autowired
     GameAdsRepository gameAdsRepository;
     @Autowired
     UserRepository userRepository;
 
-    // Create a gameAd with user reference, using a DTO.
+    // POST a gameAd with user reference, using a DTO.
     public GameAds createGameAd(CreateGameDTO createGameDTO) {
         User user = userRepository.findById(createGameDTO.getUserId())
                 .orElseThrow(() -> new RuntimeException("User not found."));
@@ -47,23 +49,41 @@ public class GameAdsService {
         return gameAds.stream().map(this::convertToDTO).collect(Collectors.toList());
     }
 
-    // Update a gameAd
-    public GameAds updateGameAd(GameAds gameAds) {
-        return gameAdsRepository.save(gameAds);
+    // UPDATED UPDATE a gameAD
+    public GameAds updateGameAd(String id, GameAds updatedGameAd) {
+        return gameAdsRepository.findById(id).map(existingGameAd -> {
+            if(updatedGameAd.getTitle() != null) {
+                existingGameAd.setTitle(updatedGameAd.getTitle());
+            }
+            if(updatedGameAd.getDescription() != null) {
+                existingGameAd.setDescription(updatedGameAd.getDescription());
+            }
+            if(updatedGameAd.getUpdated_at() != null) {
+                existingGameAd.setUpdated_at(updatedGameAd.getUpdated_at());
+            }
+            if(updatedGameAd.getGameDetails() != null) {
+                existingGameAd.setGameDetails(updatedGameAd.getGameDetails());
+            }
+            existingGameAd.setPrice(updatedGameAd.getPrice());
+            existingGameAd.setShippingCost(updatedGameAd.getShippingCost());
+
+            return gameAdsRepository.save(existingGameAd);
+        })
+                .orElseThrow(() -> new EntityNotFoundException("Game with id " + id + " was not found."));
     }
 
-    // Get a gameAd by id
+    // GET a gameAd by id
     public Optional<GameAds> getGameAdById(String id) {
         return gameAdsRepository.findById(id);
     }
 
-    // Delete a gameAd
+    // DELETE a gameAd
     public String deleteGameAd(String id) {
         gameAdsRepository.deleteById(id);
         return "Game Ad deleted";
     }
 
-    // Filter by tags
+    // FILTER by enum
     public List<GameAds> findGameAdsByGameDetails(List<EGameCategory> gameDetails) {
         return gameAdsRepository.findByGameDetailsIn(gameDetails);
     }
@@ -81,7 +101,6 @@ public class GameAdsService {
     private GameAdResponse convertToDTO(GameAds gameAd) {
         GameAdResponse gameAdResponse = new GameAdResponse();
 
-        //Get ID too?
         gameAdResponse.setUsername(gameAd.getUser().getUsername());
         gameAdResponse.setTitle(gameAd.getTitle());
         gameAdResponse.setDescription(gameAd.getDescription());
@@ -111,7 +130,6 @@ public class GameAdsService {
     } */
 
 
-
    /* // OLD GET all GameAds by user ID, stored for now, just in case.
     public List<GameAds> findGameAdsByUserId(String userId) {
         User user = userRepository.findById(userId).orElseThrow();
@@ -124,4 +142,11 @@ public class GameAdsService {
             }
         }
         return foundGames;
+    } */
+
+
+  /*
+    // OLD UPDATE a gameAd, stored for now, just in case.
+    public GameAds updateGameAd(GameAds gameAds) {
+        return gameAdsRepository.save(gameAds);
     } */

--- a/src/main/java/SecondRoll/demo/services/GameAdsService.java
+++ b/src/main/java/SecondRoll/demo/services/GameAdsService.java
@@ -4,16 +4,16 @@ import SecondRoll.demo.models.EGameCategory;
 import SecondRoll.demo.models.GameAds;
 import SecondRoll.demo.models.User;
 import SecondRoll.demo.payload.CreateGameDTO;
+import SecondRoll.demo.payload.response.GameAdResponse;
 import SecondRoll.demo.repository.GameAdsRepository;
 import SecondRoll.demo.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 @Service
 public class GameAdsService {
@@ -36,14 +36,15 @@ public class GameAdsService {
         gameAd.setCreated_at(createGameDTO.getCreated_at());
         gameAd.setUpdated_at(createGameDTO.getUpdated_at());
         gameAd.setGameDetails(createGameDTO.getGameDetails());
-        gameAd.setAvailable(createGameDTO.isAvailable);
 
         return gameAdsRepository.save(gameAd);
     }
 
-    // Get all gameAds
-    public List<GameAds> getAllGameAds() {
-        return gameAdsRepository.findAll();
+    // UPDATED GET all gameAds.
+    public List<GameAdResponse> getAllGameAds() {
+        List<GameAds> gameAds = gameAdsRepository.findAll();
+
+        return gameAds.stream().map(this::convertToDTO).collect(Collectors.toList());
     }
 
     // Update a gameAd
@@ -67,7 +68,51 @@ public class GameAdsService {
         return gameAdsRepository.findByGameDetailsIn(gameDetails);
     }
 
-    // Find all GameAds by user ID.
+    // UPDATED Find all GameAds by user ID.
+    public List<GameAdResponse> getUserOrders(String userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found."));
+
+        List<GameAds> userGames = gameAdsRepository.findByUserId(userId);
+        return userGames.stream().map(this::convertToDTO).collect(Collectors.toList());
+    }
+
+    // This utility-method converts the content of a GameAd-object into a GameAdResponse-object.
+    private GameAdResponse convertToDTO(GameAds gameAd) {
+        GameAdResponse gameAdResponse = new GameAdResponse();
+
+        //Get ID too?
+        gameAdResponse.setUsername(gameAd.getUser().getUsername());
+        gameAdResponse.setTitle(gameAd.getTitle());
+        gameAdResponse.setDescription(gameAd.getDescription());
+        gameAdResponse.setPrice(gameAd.getPrice());
+        gameAdResponse.setShippingCost(gameAd.getShippingCost());
+        gameAdResponse.setCreated_at(gameAd.getCreated_at());
+        gameAdResponse.setUpdated_at(gameAd.getUpdated_at());
+        gameAdResponse.setGameDetails(gameAd.gameDetails);
+
+        return gameAdResponse;
+    }
+
+    // "Roll the Dice" game ad randomizer
+    public GameAds getRandomGameAd() {
+        Random randomGameAd = new Random();
+        List<GameAds> allGameAds = gameAdsRepository.findAll();
+        int maxInt = allGameAds.size();
+        GameAds gameAds = allGameAds.get(randomGameAd.nextInt(maxInt));
+        return gameAds;
+    }
+}
+
+
+   /* // OLD GET ALL gameAds, stored for now, just in case.
+    public List<GameAds> getAllGameAds() {
+        return gameAdsRepository.findAll();
+    } */
+
+
+
+   /* // OLD GET all GameAds by user ID, stored for now, just in case.
     public List<GameAds> findGameAdsByUserId(String userId) {
         User user = userRepository.findById(userId).orElseThrow();
 
@@ -79,15 +124,4 @@ public class GameAdsService {
             }
         }
         return foundGames;
-    }
-
-
-    // "Roll the Dice" game ad randomizer
-    public GameAds getRandomGameAd() {
-        Random randomGameAd = new Random();
-        List<GameAds> allGameAds = gameAdsRepository.findAll();
-        int maxInt = allGameAds.size();
-        GameAds gameAds = allGameAds.get(randomGameAd.nextInt(maxInt));
-        return gameAds;
-    }
-}
+    } */

--- a/src/main/java/SecondRoll/demo/services/GameAdsService.java
+++ b/src/main/java/SecondRoll/demo/services/GameAdsService.java
@@ -74,7 +74,8 @@ public class GameAdsService {
 
     // GET a gameAd by id
     public Optional<GameAds> getGameAdById(String id) {
-        return gameAdsRepository.findById(id);
+        return Optional.ofNullable(gameAdsRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Game not found.")));
     }
 
     // DELETE a gameAd


### PR DESCRIPTION
Added a GameResponseDTO and updated method for getting all game ads belonging to a user for better performance.
 Tested in postman, working on my end. 

Try it for yourselves:
http://localhost:8080/api/gameAds/user/:userId

Enter a user ID as path-variable and it should return a username and all games belonging to that username with all the corresponding game info. 

I also updated the rest of the CRUD for gameads using the same GameResponseDTO to minimize the user info in the response to only return username in those aswell.
(I'm aware this should have been a separate issue)!

You can test these out in postman aswell: 

To POST a game ad: http://localhost:8080/api/gameAds
use the following body: 
{
    "userId": "",
    "title": "",
    "description": "",
    "price": ,
    "gameDetails": [""]
}

to GET ALL games: http://localhost:8080/api/gameAds/all

to PUT (update) a game ad: http://localhost:8080/api/gameAds/:gameId
Use the body from the GameAd you created and try changing a value. 

to GET a game by it's ID: http://localhost:8080/api/gameAds/:id
Enter a Game ID as path-variable. 

to DELETE a game by it's ID: http://localhost:8080/api/gameAds/:id
Enter a Game ID as path-variable.

Finally, roll the dice was also updated in the same way. It now only returns username, not all user info belonging to the game.
http://localhost:8080/api/gameAds/rolldice

Hopefully it all works for you aswell! If so, we can merge. 