### PR TITLE
98 update error messages in gamead crud

### DIFF
--- a/src/main/java/SecondRoll/demo/exception/AppExceptionHandler.java
+++ b/src/main/java/SecondRoll/demo/exception/AppExceptionHandler.java
@@ -1,0 +1,42 @@
+package SecondRoll.demo.exception;
+
+import SecondRoll.demo.payload.response.ErrorMessage;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.Date;
+
+@ControllerAdvice
+public class AppExceptionHandler extends ResponseEntityExceptionHandler {
+
+    /* Handles general exceptions and returns a simple error message and timestamp.
+    @ExceptionHandler(value = {Exception.class})
+    public ResponseEntity<Object> handleAnyException(Exception ex, WebRequest request) {
+
+        String errorMessageDetails = ex.getLocalizedMessage();
+
+        if(errorMessageDetails == null) errorMessageDetails = ex.toString();
+
+        ErrorMessage errorMessage = new ErrorMessage(new Date(), errorMessageDetails);
+
+        return new ResponseEntity<>(errorMessage, new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR);
+    } */
+
+    //Handles all exceptions related to GameAds.
+    @ExceptionHandler(value = {GameAdServiceException.class})
+    public ResponseEntity<Object> handleGameAdServiceException(GameAdServiceException ex, WebRequest request) {
+
+        String errorMessageDetails = ex.getLocalizedMessage();
+
+        if(errorMessageDetails == null) errorMessageDetails = ex.toString();
+
+        ErrorMessage errorMessage = new ErrorMessage(new Date(), errorMessageDetails);
+
+        return new ResponseEntity<>(errorMessage, new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/SecondRoll/demo/exception/AppExceptionHandler.java
+++ b/src/main/java/SecondRoll/demo/exception/AppExceptionHandler.java
@@ -14,7 +14,7 @@ import java.util.Date;
 @ControllerAdvice
 public class AppExceptionHandler extends ResponseEntityExceptionHandler {
 
-    /* Handles general exceptions and returns a simple error message and timestamp.
+    /* Handles general exceptions and returns a simple error message and timestamp. Might not need.
     @ExceptionHandler(value = {Exception.class})
     public ResponseEntity<Object> handleAnyException(Exception ex, WebRequest request) {
 
@@ -27,9 +27,9 @@ public class AppExceptionHandler extends ResponseEntityExceptionHandler {
         return new ResponseEntity<>(errorMessage, new HttpHeaders(), HttpStatus.INTERNAL_SERVER_ERROR);
     } */
 
-    //Handles all exceptions related to GameAds.
-    @ExceptionHandler(value = {GameAdServiceException.class})
-    public ResponseEntity<Object> handleGameAdServiceException(GameAdServiceException ex, WebRequest request) {
+    //Handles specific exceptions.
+    @ExceptionHandler(value = {ServiceException.class})
+    public ResponseEntity<Object> handleSpecificException(ServiceException ex, WebRequest request) {
 
         String errorMessageDetails = ex.getLocalizedMessage();
 

--- a/src/main/java/SecondRoll/demo/exception/GameAdServiceException.java
+++ b/src/main/java/SecondRoll/demo/exception/GameAdServiceException.java
@@ -1,0 +1,8 @@
+package SecondRoll.demo.exception;
+
+public class GameAdServiceException extends RuntimeException {
+
+    public GameAdServiceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/SecondRoll/demo/exception/GameAdServiceException.java
+++ b/src/main/java/SecondRoll/demo/exception/GameAdServiceException.java
@@ -1,8 +1,0 @@
-package SecondRoll.demo.exception;
-
-public class GameAdServiceException extends RuntimeException {
-
-    public GameAdServiceException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/SecondRoll/demo/exception/ServiceException.java
+++ b/src/main/java/SecondRoll/demo/exception/ServiceException.java
@@ -1,0 +1,8 @@
+package SecondRoll.demo.exception;
+
+public class ServiceException extends RuntimeException {
+
+    public ServiceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/SecondRoll/demo/payload/response/ErrorMessage.java
+++ b/src/main/java/SecondRoll/demo/payload/response/ErrorMessage.java
@@ -1,0 +1,36 @@
+package SecondRoll.demo.payload.response;
+
+import java.util.Date;
+
+//This class is called to display a custom error message for exceptions.
+public class ErrorMessage {
+    private Date timestamp;
+    private String messsage;
+
+    //Empty constructor.
+    public ErrorMessage() {
+    }
+
+    //Constructor with timestamp and error message.
+    public ErrorMessage(Date timestamp, String messsage) {
+        this.timestamp = timestamp;
+        this.messsage = messsage;
+    }
+
+    //Getters and setters.
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Date timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getMesssage() {
+        return messsage;
+    }
+
+    public void setMesssage(String messsage) {
+        this.messsage = messsage;
+    }
+}

--- a/src/main/java/SecondRoll/demo/services/GameAdsService.java
+++ b/src/main/java/SecondRoll/demo/services/GameAdsService.java
@@ -134,6 +134,11 @@ public class GameAdsService {
         gameAdResponse.setShippingCost(gameAd.getShippingCost());
         gameAdResponse.setCreated_at(gameAd.getCreated_at());
         gameAdResponse.setUpdated_at(gameAd.getUpdated_at());
+        gameAdResponse.setGameCreator(gameAd.getGameCreator());
+        gameAdResponse.setGamePlayTime(gameAd.getGamePlayTime());
+        gameAdResponse.setGameRecommendedAge(gameAd.getGameRecommendedAge());
+        gameAdResponse.setGamePlayers(gameAd.getGamePlayers());
+        gameAdResponse.setGameGenres(gameAd.getGameGenres());
      //   gameAdResponse.setGameDetails(gameAd.gameDetails);
 
         return gameAdResponse;

--- a/src/main/java/SecondRoll/demo/services/GameAdsService.java
+++ b/src/main/java/SecondRoll/demo/services/GameAdsService.java
@@ -9,6 +9,8 @@ import SecondRoll.demo.payload.response.GameAdResponse;
 import SecondRoll.demo.repository.GameAdsRepository;
 import SecondRoll.demo.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -116,8 +118,11 @@ public class GameAdsService {
 
     // UPDATED Find all GameAds by user ID.
     public List<GameAdResponse> getUserOrders(String userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found."));
+        Optional<User> user = userRepository.findById(userId);
+        if (!user.isPresent()) {
+            return (List<GameAdResponse>) ResponseEntity.status(HttpStatus.NOT_FOUND);
+        }
+
 
         List<GameAds> userGames = gameAdsRepository.findByUserId(userId);
         return userGames.stream().map(this::convertToDTO).collect(Collectors.toList());

--- a/src/main/java/SecondRoll/demo/services/GameAdsService.java
+++ b/src/main/java/SecondRoll/demo/services/GameAdsService.java
@@ -1,7 +1,7 @@
 package SecondRoll.demo.services;
 
 
-import SecondRoll.demo.exception.GameAdServiceException;
+import SecondRoll.demo.exception.ServiceException;
 import SecondRoll.demo.models.GameAds;
 import SecondRoll.demo.models.User;
 import SecondRoll.demo.payload.CreateGameDTO;
@@ -25,7 +25,7 @@ public class GameAdsService {
     // POST a gameAd with user reference, using a DTO.
     public GameAds createGameAd(CreateGameDTO createGameDTO) {
         User user = userRepository.findById(createGameDTO.getUserId())
-                .orElseThrow(() -> new GameAdServiceException("User not found."));
+                .orElseThrow(() -> new ServiceException("User not found."));
 
         GameAds gameAd = new GameAds();
         gameAd.setUser(user);
@@ -72,13 +72,13 @@ public class GameAdsService {
 
             return gameAdsRepository.save(existingGameAd);
         })
-                .orElseThrow(() -> new GameAdServiceException("Game with id " + id + " was not found."));
+                .orElseThrow(() -> new ServiceException("Game with id " + id + " was not found."));
     }
 
     // GET a gameAd by id
     public Optional<GameAds> getGameAdById(String id) {
         return Optional.ofNullable(gameAdsRepository.findById(id)
-                .orElseThrow(() -> new GameAdServiceException("Game not found.")));
+                .orElseThrow(() -> new ServiceException("Game not found.")));
     }
 
     // DELETE a gameAd
@@ -116,7 +116,7 @@ public class GameAdsService {
     public List<GameAdResponse> getUserOrders(String userId) {
         Optional<User> user = userRepository.findById(userId);
         if (!user.isPresent()) {
-            throw new GameAdServiceException("User not found.");
+            throw new ServiceException("User not found.");
         }
 
         List<GameAds> userGames = gameAdsRepository.findByUserId(userId);


### PR DESCRIPTION
I have added a custom Exception Handler to handle specific errors such as invalid user/game ID's, which also display custom messages. 
--------------------------------------------------------------------------------------------------------------------------------------------
Test the custom error messages for Game Ads in postman via my branch: 

git checkout 98-update-error-messages-in-gamead-crud
--------------------------------------------------------------------------------------------------------------------------------------------
Try getting a game based on game ID: http://localhost:8080/api/gameAds/:id
Just write some gibberish as the ID value and postman should return an error message with "Game not found".

Try getting all games by a user ID: http://localhost:8080/api/gameAds/user/:userId 
And same as before, write something random as the ID value and it should return "User not found".

Try creating a game: http://localhost:8080/api/gameAds 
And set the userID to some none-existing gibberish aswell, it should return an error message with "User not found". 

Try updating a game: http://localhost:8080/api/gameAds/:gameId
And set the game ID value to whatever, it should return "Game with id (id) was not found".