### PR TITLE
104 look over and add appropriate role authentication to endpoints

### DIFF
--- a/src/main/java/SecondRoll/demo/controllers/GameAdsController.java
+++ b/src/main/java/SecondRoll/demo/controllers/GameAdsController.java
@@ -46,7 +46,7 @@ public class GameAdsController {
 
     // UPDATED PUT
     @PutMapping("/{gameId}")
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("hasRole('USER')") //admin
     public ResponseEntity<?> updateGameAd(@PathVariable String gameId, @RequestBody GameAds gameDetails) {
         try {
             GameAds updatedGameAd = gameAdsService.updateGameAd(gameId, gameDetails);
@@ -63,7 +63,7 @@ public class GameAdsController {
         }
     }
 
-    // GET a gameAd by ID.
+    // GET a gameAd by ID. // user and admin
     @GetMapping(value = "/{id}")
     public ResponseEntity<?> getGameAdById(@PathVariable String id) {
         try {
@@ -80,7 +80,7 @@ public class GameAdsController {
         }
     }
 
-    // Delete by ID.
+    // Delete by ID. // add user auth
     @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
     @PreAuthorize("hasRole('ADMIN')")
     public String deleteGameAd(@PathVariable String id) {
@@ -94,7 +94,7 @@ public class GameAdsController {
     }*/
 
 
-    // GET all game ads belonging to a user.
+    // GET all game ads belonging to a user. //amin och user
     @GetMapping("/user/{userId}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<GameAdResponse>> getUserGameAds(@PathVariable String userId) {

--- a/src/main/java/SecondRoll/demo/controllers/OrderController.java
+++ b/src/main/java/SecondRoll/demo/controllers/OrderController.java
@@ -29,6 +29,7 @@ public class OrderController {
     UserDetailsServiceImpl userDetailsService;
 
     @PostMapping
+    @PreAuthorize("hasRole('USER')")
     //Sending in OrderDTO object as a request
     public ResponseEntity<Order> createOrder(@RequestBody OrderDTO orderDTO) {
         //Getting user id and game ad id and creates the order in database

--- a/src/main/java/SecondRoll/demo/security/WebSecurityConfig.java
+++ b/src/main/java/SecondRoll/demo/security/WebSecurityConfig.java
@@ -66,6 +66,12 @@ public class WebSecurityConfig {
                                 .requestMatchers("/api/gameAds/rolldice").permitAll()
                                 .requestMatchers("/api/gameAds/sortbydate/**").permitAll()
                                 .requestMatchers("/api/gameAds/sortbyprice/**").permitAll()
+                                .requestMatchers("/api/gameAds/findbytitle/{title}").permitAll()
+                                .requestMatchers("/api/gameAds/findbygenre/{genre}").permitAll()
+                                .requestMatchers("/api/gameAds/findbycreator/{creator}").permitAll()
+                                .requestMatchers("/api/gameAds/findbygametime/{gameTime}").permitAll()
+                                .requestMatchers("/api/gameAds/findbyage/{recommendedAge}").permitAll()
+                                .requestMatchers("/api/gameAds/findbyplayers/{players}").permitAll()
                                 .anyRequest().authenticated()
                 );
 

--- a/src/main/java/SecondRoll/demo/security/WebSecurityConfig.java
+++ b/src/main/java/SecondRoll/demo/security/WebSecurityConfig.java
@@ -75,8 +75,8 @@ public class WebSecurityConfig {
                                 .requestMatchers("/api/users/profile/{username}").hasAnyRole("USER", "ADMIN")
 
                                 .requestMatchers("/api/orders").hasRole("USER")
-                                .requestMatchers("/api/orders/buyerhistory/{buyerId}").hasAnyRole("USER", "ADMIN")
-                                .requestMatchers("/api/orders/sellerhistory/{sellerId}").hasAnyRole("USER", "ADMIN")
+                                //.requestMatchers("/api/orders/buyerhistory/{buyerId}").hasAnyRole("USER", "ADMIN")
+                                //.requestMatchers("/api/orders/sellerhistory/{sellerId}").hasAnyRole("USER", "ADMIN")
                                 .anyRequest().authenticated()
                 );
 

--- a/src/main/java/SecondRoll/demo/security/WebSecurityConfig.java
+++ b/src/main/java/SecondRoll/demo/security/WebSecurityConfig.java
@@ -56,8 +56,6 @@ public class WebSecurityConfig {
     // titta över det här kanske hittar ni fler scenarion ni behöver tänka på? ändra authorization mitt tips är auth på
     // metodnivå istället. Vissa kan säker ligga kvar kanske men gå igenom varje end point för att se vilken auth som krävs.
 
-    // obs obs, ändra framöver så att inte admin kan lägga in orders
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable())


### PR DESCRIPTION
All endpoints has been gone through in all controllers to make sure they have the correct authentication access based on either user or admin role. Since we've used @PreAuthorize for each method in the controllers there is no need to keep those authorization endpoints in WebSecurityConfig.

WebSecurityConfig now only contains endpoints with "permitAll"-access.

**To test in Postman**
git checkout 104-look-over-and-add-appropriate-role-authentication-to-endpoints

All endpoints needs to be tested for both user and admin roles. If an endpoint has limited access (user OR admin), actively try to access that endpoint to confirm that the authorization works as it should.
When logged in as a user, also try to access other user id's, ex. another users seller or buyer history.

Thank you and good luck! :)

**EDIT**
[PR instructions.txt](https://github.com/Jerkinator/secondRoll/files/14602108/PR.instructions.txt)

Added a document with endpoints, functionality, auth access and request type since it got totally fucked up in when I posted the PR buhu.